### PR TITLE
Fixes zeeqs helm chart deployment (hazelcast host Env. Variable name)

### DIFF
--- a/charts/zeebe-zeeqs-helm/templates/deployment.yaml
+++ b/charts/zeebe-zeeqs-helm/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         env:
           - name: SERVER_PORT
             value: "{{ .Values.global.port }}"
-          - name: ZEEBE_HAZELCAST_CONNECTION
+          - name: ZEEBE_CLIENT_WORKER_HAZELCAST_CONNECTION
           {{ if .Values.global.hazelcast }}
             value: {{ .Values.global.hazelcast }}
           {{ else }}


### PR DESCRIPTION
The "hazelcast" env variable on zeeqs helm chart was outdated, causing a bad deployment and resulting in the application crash when receiving an http request (/graphiql or POST).